### PR TITLE
POSTGRESQL or MYSQL is required - hsqldb can't be used

### DIFF
--- a/helpdesk-core/src/main/java/org/esupportail/helpdesk/dao/HibernateDaoServiceImpl.java
+++ b/helpdesk-core/src/main/java/org/esupportail/helpdesk/dao/HibernateDaoServiceImpl.java
@@ -4586,7 +4586,7 @@ implements DaoService {
 		} else if (jdbcUrl.startsWith("jdbc:postgresql")) {
 			databaseType = DATABASE_TYPE_POSTGRES;
 		} else {
-			throw new ConfigException("unknown database type for JDBC URL [" + jdbcUrl + "]");
+			throw new ConfigException("unknown database type for JDBC URL [" + jdbcUrl + "] - note that POSTGRESQL or MYSQL is required");
 		}
 	}
 

--- a/helpdesk-web-jsf-servlet/src/main/jetty/jetty-env.xml
+++ b/helpdesk-web-jsf-servlet/src/main/jetty/jetty-env.xml
@@ -3,13 +3,13 @@
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <New id="myds" class="org.eclipse.jetty.plus.jndi.Resource">
-        <Arg>jdbc/helpdesk</Arg>
+        <Arg>jdbc/helpdeskDB</Arg>
         <Arg>
             <New class="org.apache.commons.dbcp.BasicDataSource">
                 <Set name="driverClassName">org.hsqldb.jdbcDriver</Set>
-                <Set name="url">jdbc:hsqldb:mem:helpdesk</Set>
-                <Set name="username">sa</Set>
-                <Set name="password"></Set>
+                <Set name="url">jdbc:mysql://mysqldev.domain.edu/base</Set>
+                <Set name="username">user</Set>
+                <Set name="password">!pwd!</Set>
             </New>
         </Arg>
     </New>


### PR DESCRIPTION
Plus cohérent avec le config.properties.example ... sinon cela peut induire en erreur ; on peut croire que le Helpdesk supporte le HSQL pour un déploiement rapide / de test ...
Merci,
Vincent.
